### PR TITLE
Fix json output of messages in listen

### DIFF
--- a/src/listen.rs
+++ b/src/listen.rs
@@ -382,31 +382,31 @@ async fn handle_syncroommessageevent(
         debug!("Skipping message from itself because --listen-self is not set.");
         return;
     }
-    if !context.output.is_text() {
-        // Serialize it to a JSON string.
-        let j = match serde_json::to_string("") {
-            Ok(jsonstr) => {
-                // this event does not contain the room_id, other events do.
-                // People are missing the room_id in output.
-                // Nasty hack: inserting the room_id into the JSON string.
-                let mut s = jsonstr;
-                s.insert_str(s.len() - 1, ",\"event_id\":\"\"");
-                s.insert_str(s.len() - 2, ev.event_id().as_str());
-                s.insert_str(s.len() - 1, ",\"sender\":\"\"");
-                s.insert_str(s.len() - 2, ev.sender().as_str());
-                s.insert_str(s.len() - 1, ",\"origin_server_ts\":\"\"");
-                s.insert_str(s.len() - 2, &ev.origin_server_ts().0.to_string());
-                s.insert_str(s.len() - 1, ",\"room_id\":\"\"");
-                s.insert_str(s.len() - 2, room.room_id().as_str());
-                s
-            }
-            Err(e) => e.to_string(),
-        };
-        println!("{}", j);
-        return;
-    }
     match ev {
         SyncMessageLikeEvent::Original(orginialmessagelikeevent) => {
+            if !context.output.is_text() {
+                // Serialize it to a JSON string.
+                let j = match serde_json::to_string(&orginialmessagelikeevent.content) {
+                    Ok(jsonstr) => {
+                        // this event does not contain the room_id, other events do.
+                        // People are missing the room_id in output.
+                        // Nasty hack: inserting the room_id into the JSON string.
+                        let mut s = jsonstr;
+                        s.insert_str(s.len() - 1, ",\"event_id\":\"\"");
+                        s.insert_str(s.len() - 2, orginialmessagelikeevent.event_id.as_str());
+                        s.insert_str(s.len() - 1, ",\"sender\":\"\"");
+                        s.insert_str(s.len() - 2, orginialmessagelikeevent.sender.as_str());
+                        s.insert_str(s.len() - 1, ",\"origin_server_ts\":\"\"");
+                        s.insert_str(s.len() - 2, &orginialmessagelikeevent.origin_server_ts.0.to_string());
+                        s.insert_str(s.len() - 1, ",\"room_id\":\"\"");
+                        s.insert_str(s.len() - 2, room.room_id().as_str());
+                        s
+                    }
+                    Err(e) => e.to_string(),
+                };
+                println!("{}", j);
+                return;
+            }
             handle_originalsyncmessagelikeevent(
                 &orginialmessagelikeevent,
                 &RoomId::parse(room.room_id()).unwrap(),


### PR DESCRIPTION
Json output of text messages in listen is broken in v0.10.0. This fix produces output parsable Json as before.