### PR TITLE
fix error 403 when creating DM room with empty alias

### DIFF
--- a/src/mclient.rs
+++ b/src/mclient.rs
@@ -1267,7 +1267,7 @@ pub(crate) async fn room_create(
         }
 
         request.name = Some(names2[i].clone());
-        request.room_alias_name = Some(aliases2[i].clone());
+        request.room_alias_name = Some(aliases2[i].clone()).filter(|s| !s.is_empty());
         request.topic = Some(topics2[i].clone());
         request.is_direct = is_dm;
         let usr: OwnedUserId;


### PR DESCRIPTION
fix for https://github.com/8go/matrix-commander-rs/issues/154