### PR TITLE
Fix --tail panic on undecryptable events

### DIFF
--- a/src/listen.rs
+++ b/src/listen.rs
@@ -681,7 +681,33 @@ pub(crate) async fn listen_tail(
             let rawevent = if let TimelineEventKind::Decrypted(decrypted) = &anytimelineevent.kind {
                 &decrypted.event
             } else {
-                panic!()
+                // The event could not be decrypted (unable-to-decrypt, UTD) or it
+                // is a plaintext event. Previously this branch did `panic!()`,
+                // so a single UTD event in the tail window crashed the whole
+                // program. Instead, emit a notice and carry on with the next
+                // event. To read encrypted history, the device must be verified
+                // and the room keys present; '--restore-backup' can fetch keys
+                // from the server-side key backup.
+                let utdraw = anytimelineevent.raw();
+                let event_id = anytimelineevent
+                    .event_id()
+                    .map(|e| e.to_string())
+                    .unwrap_or_default();
+                let sender = utdraw
+                    .deserialize()
+                    .ok()
+                    .map(|e| e.sender().to_string())
+                    .unwrap_or_default();
+                if !output.is_text() {
+                    println!("{}", utdraw.json());
+                } else {
+                    println!(
+                        "Message: type Encrypted: room {:?}, sender {:?}, event_id {:?}, message could not be decrypted",
+                        roomid, sender, event_id,
+                    );
+                }
+                err_count += 1;
+                continue;
             };
             // print_type_of(&rawevent); // ruma_common::events::enums::AnyTimelineEvent
             debug!("rawevent = value is {:?}\n", rawevent);


### PR DESCRIPTION
`listen_tail()` assumed every fetched timeline event was a `Decrypted`
variant and called `panic!()` for anything else (`src/listen.rs:684`). A
single unable-to-decrypt (UTD) or plaintext event in the tail window
therefore crashes the whole program.

This happens routinely on a verified device that is missing the room key for
some older event (e.g. a megolm session that was never in the key backup):

```
$ matrix-commander-rs --tail 8 --room '!room:server'
Message: type Text: body "...", ...
thread 'main' panicked at src/listen.rs:684:17:
explicit panic
```

Handle the non-`Decrypted` case gracefully instead: print a notice (in text
form, or the raw JSON for `--output json`), count it toward `err_count`, and
continue with the next event. `--tail` now prints what it can and skips what
it cannot decrypt.
