### PR TITLE
Fix #207: Add support for PlainText events when tailing.

### DIFF
--- a/src/listen.rs
+++ b/src/listen.rs
@@ -678,45 +678,41 @@ pub(crate) async fn listen_tail(
             let anytimelineevent = &chunk[chunk.len() - 1 - index]; // reverse ordering, getting older msg first
                                                                     // Todo : dump the JSON serialized string via Json API
 
-            let rawevent = if let TimelineEventKind::Decrypted(decrypted) = &anytimelineevent.kind {
-                &decrypted.event
-            } else {
-                // The event could not be decrypted (unable-to-decrypt, UTD) or it
-                // is a plaintext event. Previously this branch did `panic!()`,
-                // so a single UTD event in the tail window crashed the whole
-                // program. Instead, emit a notice and carry on with the next
-                // event. To read encrypted history, the device must be verified
-                // and the room keys present; '--restore-backup' can fetch keys
-                // from the server-side key backup.
-                let utdraw = anytimelineevent.raw();
-                let event_id = anytimelineevent
-                    .event_id()
-                    .map(|e| e.to_string())
-                    .unwrap_or_default();
-                let sender = utdraw
-                    .deserialize()
-                    .ok()
-                    .map(|e| e.sender().to_string())
-                    .unwrap_or_default();
-                if !output.is_text() {
-                    println!("{}", utdraw.json());
-                } else {
-                    println!(
-                        "Message: type Encrypted: room {:?}, sender {:?}, event_id {:?}, message could not be decrypted",
-                        roomid, sender, event_id,
-                    );
+            let rawevent = match &anytimelineevent.kind {
+                TimelineEventKind::Decrypted(decrypted) => &decrypted.event,
+                TimelineEventKind::PlainText { event } => {
+                    event.cast_ref_unchecked::<AnyTimelineEvent>()
                 }
-                err_count += 1;
-                continue;
+                _ => {
+                    // The event could not be decrypted (unable-to-decrypt, UTD) or it
+                    // is a plaintext event. Previously this branch did `panic!()`,
+                    // so a single UTD event in the tail window crashed the whole
+                    // program. Instead, emit a notice and carry on with the next
+                    // event. To read encrypted history, the device must be verified
+                    // and the room keys present; '--restore-backup' can fetch keys
+                    // from the server-side key backup.
+                    let utdraw = anytimelineevent.raw();
+                    let event_id = anytimelineevent
+                        .event_id()
+                        .map(|e| e.to_string())
+                        .unwrap_or_default();
+                    let sender = utdraw
+                        .deserialize()
+                        .ok()
+                        .map(|e| e.sender().to_string())
+                        .unwrap_or_default();
+                    if !output.is_text() {
+                        println!("{}", utdraw.json());
+                    } else {
+                        println!(
+                            "Message: type Encrypted: room {:?}, sender {:?}, event_id {:?}, message could not be decrypted",
+                            roomid, sender, event_id,
+                        );
+                    }
+                    err_count += 1;
+                    continue;
+                }
             };
-            // print_type_of(&rawevent); // ruma_common::events::enums::AnyTimelineEvent
-            debug!("rawevent = value is {:?}\n", rawevent);
-            // rawevent = Ok(MessageLike(RoomMessage(Original(OriginalMessageLikeEvent { content: RoomMessageEventContent {
-            // msgtype: Text(TextMessageEventContent { body: "54", formatted: None }), relates_to: Some(_Custom) }, event_id: "$xxx", sender: "@u:some.homeserver.org", origin_server_ts: MilliSecondsSinceUnixEpoch(123), room_id: "!rrr:some.homeserver.org", unsigned: MessageLikeUnsigned { age: Some(123), transaction_id: None, relations: None } }))))
-            if !output.is_text() {
-                println!("{}", rawevent.json());
-                continue;
-            }
 
             match rawevent.deserialize().unwrap() {
                 AnyTimelineEvent::MessageLike(anymessagelikeevent) => {

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -49,7 +49,7 @@ use matrix_sdk::{
             FileMessageEventContent,
             ImageMessageEventContent,
             MessageType,
-            // NoticeMessageEventContent,
+            NoticeMessageEventContent,
             // OriginalRoomMessageEvent, OriginalSyncRoomMessageEvent,
             // RedactedRoomMessageEventContent, RoomMessageEvent,
             // OriginalSyncRoomEncryptedEvent,
@@ -163,6 +163,15 @@ fn handle_originalsyncmessagelikeevent(
                 println!(
                     "Message: type Video: body {:?}, room {:?}, sender {:?}, event id {:?}, source {:?}, info {:?}",
                     body, room_id, ev.sender, ev.event_id, source, info,
+                );
+            }
+            MessageType::Notice(noticemessageeventcontent) => {
+                let NoticeMessageEventContent {
+                    body, formatted, ..
+                } = noticemessageeventcontent;
+                println!(
+                    "Message: type Notice: body {:?}, room {:?}, sender {:?}, event id {:?}, formatted {:?}, ",
+                    body, room_id, ev.sender, ev.event_id, formatted,
                 );
             }
             _ => {
@@ -681,6 +690,12 @@ pub(crate) async fn listen_tail(
             let rawevent = match &anytimelineevent.kind {
                 TimelineEventKind::Decrypted(decrypted) => &decrypted.event,
                 TimelineEventKind::PlainText { event } => {
+                    // cast_ref_unchecked is needed to convert from AnySyncTimelineEvent to AnyTimelineEvent.
+                    // AnyTimelineEvent differs from AnySyncTimelineEvent in that the event has an additional room_id field.
+                    // However all room messages are required to have a room_id field as specified in the
+                    // [client-server-api spec](https://spec.matrix.org/latest/client-server-api/#room-event-format).
+                    // Therefore, it is fine to cast from AnySyncTimelineEvent to AnyTimelineEvent **here** since the
+                    // rawevent will always deserialize correctly.
                     event.cast_ref_unchecked::<AnyTimelineEvent>()
                 }
                 _ => {

--- a/src/mclient.rs
+++ b/src/mclient.rs
@@ -32,8 +32,8 @@ use matrix_sdk::{
     // encryption::CryptoStoreError,
     // deserialized_responses::RawSyncOrStrippedState,
     authentication::{matrix::MatrixSession, SessionTokens},
-    cross_process_lock::CrossProcessLockConfig,
     config::{RequestConfig, StoreConfig, SyncSettings},
+    cross_process_lock::CrossProcessLockConfig,
     media::{MediaFormat, MediaRequestParameters},
     room,
     room::{Room, RoomMember},
@@ -498,7 +498,9 @@ async fn create_client(homeserver: &Url, ap: &Args) -> Result<Client, Error> {
     // let builder = if let Some(proxy) = cli.proxy { builder.proxy(proxy) } else { builder };
     let builder = Client::builder()
         .homeserver_url(homeserver)
-        .store_config(StoreConfig::new(CrossProcessLockConfig::MultiProcess { holder_name: "".to_owned()}))
+        .store_config(StoreConfig::new(CrossProcessLockConfig::MultiProcess {
+            holder_name: "".to_owned(),
+        }))
         .request_config(RequestConfig::new().timeout(Duration::from_secs(ap.timeout)));
     let client = builder
         .sqlite_store(sqlitestorehome, None)


### PR DESCRIPTION
In #207 running `matrix-commander-rs --tail <N>` was panicking when streaming events from unencrypted (public) rooms as the PlainText TimelineEvent is unsupported. #208 stops the `--tail` flag from panicking but doesn't add support for PlainText events. This PR adds:

- Support for plain text events when using the `--tail` flag.
- Support for NoticeMessage events in `handle_originalsyncmessagelikeevent` so that room notices appear in the tailed output.