### PR TITLE
Fix #215: Disable excessive `matrix_sdk::http_client` error logging.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3387,11 +3387,42 @@ async fn main() -> Result<(), Error> {
         }
         Ordering::Less => (),
     }
+    // Suppress matrix_sdk::http_client logs in normal operation as they are not useful for end
+    // users and can be very verbose. If RUST_LOG already contains a directive whose target is a
+    // prefix of (or equal to) matrix_sdk::http_client (e.g. `matrix_sdk` or
+    // `matrix_sdk::http_client`), we respect the user's choice and do not force the target off.
+    const HTTP_CLIENT_TARGET: &str = "matrix_sdk::http_client";
+    let http_client_overridden =
+        env::var("RUST_LOG")
+            .unwrap_or_default()
+            .split(',')
+            .any(|directive| {
+                // Strip the `=level` suffix and any `[span{...}]` filter to isolate the target.
+                // E.g. `target[span{field=value}]=level` becomes `target`.
+                let target = directive
+                    .trim()
+                    .split('=')
+                    .next()
+                    .unwrap_or("")
+                    .split('[')
+                    .next()
+                    .unwrap_or("")
+                    .trim();
+                !target.is_empty() && HTTP_CLIENT_TARGET.starts_with(target)
+            });
+    let mut llfilter = EnvFilter::from_default_env();
+    if !http_client_overridden {
+        llfilter = llfilter.add_directive(
+            format!("{}=off", HTTP_CLIENT_TARGET)
+                .parse()
+                .expect("hard-coded tracing directive must parse"),
+        );
+    }
     match ap.log_level.clone() {
         None => {
             tracing_subscriber::fmt()
                 .with_writer(io::stderr)
-                .with_env_filter(EnvFilter::from_default_env()) // support the standard RUST_LOG env variable
+                .with_env_filter(llfilter)
                 .init();
             debug!(
                 "Neither --debug nor --log-level was used. Using environment variable RUST_LOG."
@@ -3404,18 +3435,25 @@ async fn main() -> Result<(), Error> {
                         "Value 'none' not allowed for --log-level argument",
                     ));
                 }
-                // .with_env_filter("matrix_commander_rs=debug") // only set matrix_commander_rs
-                let mut rlogstr: String = BIN_NAME_UNDERSCORE.to_owned();
-                rlogstr.push('='); // add char
-                rlogstr.push_str(&llvec[0].to_string());
+                llfilter = llfilter
+                    .add_directive(
+                        format!("{}={}", BIN_NAME_UNDERSCORE, llvec[0])
+                            .parse()
+                            .expect("hard-coded tracing directive must parse"),
+                    )
+                    .add_directive(
+                        format!("{}={}", HTTP_CLIENT_TARGET, llvec[0])
+                            .parse()
+                            .expect("hard-coded tracing directive must parse"),
+                    );
                 tracing_subscriber::fmt()
                     .with_writer(io::stderr)
-                    .with_env_filter(rlogstr.clone()) // support the standard RUST_LOG env variable for default value
+                    .with_env_filter(llfilter.clone()) // support the standard RUST_LOG env variable for default value
                     .init();
                 debug!(
                     "The --debug or --log-level was used once or with one value. \
                     Specifying logging equivalent to RUST_LOG setting of '{}'.",
-                    rlogstr
+                    llfilter
                 );
             } else {
                 if llvec[0].is_none() || llvec[1].is_none() {
@@ -3423,21 +3461,25 @@ async fn main() -> Result<(), Error> {
                         "Value 'none' not allowed for --log-level argument",
                     ));
                 }
-                // RUST_LOG="error,matrix_commander_rs=debug"  .. This will only show matrix-commander-rs
-                // debug info, and errors for all other modules
-                let mut rlogstr: String = llvec[1].to_string().to_owned();
-                rlogstr.push(','); // add char
-                rlogstr.push_str(BIN_NAME_UNDERSCORE);
-                rlogstr.push('=');
-                rlogstr.push_str(&llvec[0].to_string());
+                llfilter = llfilter
+                    .add_directive(
+                        format!("{}={}", BIN_NAME_UNDERSCORE, llvec[1])
+                            .parse()
+                            .expect("hard-coded tracing directive must parse"),
+                    )
+                    .add_directive(
+                        format!("{}={}", HTTP_CLIENT_TARGET, llvec[1])
+                            .parse()
+                            .expect("hard-coded tracing directive must parse"),
+                    );
                 tracing_subscriber::fmt()
                     .with_writer(io::stderr)
-                    .with_env_filter(rlogstr.clone())
+                    .with_env_filter(llfilter.clone())
                     .init();
                 debug!(
                     "The --debug or --log-level was used twice or with two values. \
                     Specifying logging equivalent to RUST_LOG setting of '{}'.",
-                    rlogstr
+                    llfilter
                 );
             }
             if llvec.len() > 2 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3397,7 +3397,9 @@ async fn main() -> Result<(), Error> {
             .unwrap_or_default()
             .split(',')
             .any(|directive| {
-                // Strip the `=level` suffix and any `[span{...}]` filter to isolate the target.
+                // The format of the EnvFilter directive is `target[span{...}]=level` and is
+                // documented in the [tracing_subscriber crate](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html).
+                // We need to strip the `=level` suffix and any `[span{...}]` filter to isolate the target.
                 // E.g. `target[span{field=value}]=level` becomes `target`.
                 let target = directive
                     .trim()
@@ -3411,15 +3413,15 @@ async fn main() -> Result<(), Error> {
                 !target.is_empty() && HTTP_CLIENT_TARGET.starts_with(target)
             });
     let mut llfilter = EnvFilter::from_default_env();
-    if !http_client_overridden {
-        llfilter = llfilter.add_directive(
-            format!("{}=off", HTTP_CLIENT_TARGET)
-                .parse()
-                .expect("hard-coded tracing directive must parse"),
-        );
-    }
     match ap.log_level.clone() {
         None => {
+            if !http_client_overridden {
+                llfilter = llfilter.add_directive(
+                    format!("{}=off", HTTP_CLIENT_TARGET)
+                        .parse()
+                        .expect("hard-coded tracing directive must parse"),
+                );
+            }
             tracing_subscriber::fmt()
                 .with_writer(io::stderr)
                 .with_env_filter(llfilter)
@@ -3429,59 +3431,35 @@ async fn main() -> Result<(), Error> {
             );
         }
         Some(llvec) => {
-            if llvec.len() == 1 {
-                if llvec[0].is_none() {
-                    return Err(Error::UnsupportedCliParameter(
-                        "Value 'none' not allowed for --log-level argument",
-                    ));
-                }
-                llfilter = llfilter
-                    .add_directive(
-                        format!("{}={}", BIN_NAME_UNDERSCORE, llvec[0])
-                            .parse()
-                            .expect("hard-coded tracing directive must parse"),
-                    )
-                    .add_directive(
-                        format!("{}={}", HTTP_CLIENT_TARGET, llvec[0])
-                            .parse()
-                            .expect("hard-coded tracing directive must parse"),
-                    );
-                tracing_subscriber::fmt()
-                    .with_writer(io::stderr)
-                    .with_env_filter(llfilter.clone()) // support the standard RUST_LOG env variable for default value
-                    .init();
-                debug!(
-                    "The --debug or --log-level was used once or with one value. \
-                    Specifying logging equivalent to RUST_LOG setting of '{}'.",
-                    llfilter
-                );
-            } else {
-                if llvec[0].is_none() || llvec[1].is_none() {
-                    return Err(Error::UnsupportedCliParameter(
-                        "Value 'none' not allowed for --log-level argument",
-                    ));
-                }
-                llfilter = llfilter
-                    .add_directive(
-                        format!("{}={}", BIN_NAME_UNDERSCORE, llvec[1])
-                            .parse()
-                            .expect("hard-coded tracing directive must parse"),
-                    )
-                    .add_directive(
-                        format!("{}={}", HTTP_CLIENT_TARGET, llvec[1])
-                            .parse()
-                            .expect("hard-coded tracing directive must parse"),
-                    );
-                tracing_subscriber::fmt()
-                    .with_writer(io::stderr)
-                    .with_env_filter(llfilter.clone())
-                    .init();
-                debug!(
-                    "The --debug or --log-level was used twice or with two values. \
-                    Specifying logging equivalent to RUST_LOG setting of '{}'.",
-                    llfilter
-                );
+            // ap.log_level will always be set with a Some(llvec) value of at least length 1.
+            // We take the larger of the first two indices in llvec to be the log-level we use
+            // and disregard any log-levels specified beyond the first two.
+            let llindex = (llvec.len() - 1).min(1);
+            if llvec[..(llindex + 1)].iter().any(|ll| ll.is_none()) {
+                return Err(Error::UnsupportedCliParameter(
+                    "Value 'none' not allowed for --log-level argument",
+                ));
             }
+            llfilter = llfilter
+                .add_directive(
+                    format!("{}={}", BIN_NAME_UNDERSCORE, llvec[llindex])
+                        .parse()
+                        .expect("hard-coded tracing directive must parse"),
+                )
+                .add_directive(
+                    format!("{}={}", HTTP_CLIENT_TARGET, llvec[llindex])
+                        .parse()
+                        .expect("hard-coded tracing directive must parse"),
+                );
+            tracing_subscriber::fmt()
+                .with_writer(io::stderr)
+                .with_env_filter(llfilter.clone()) // support the standard RUST_LOG env variable for default value
+                .init();
+            debug!(
+                "--debug or --log-level was specified. \
+                Logging set to the equivalent of RUST_LOG='{}'.",
+                llfilter
+            );
             if llvec.len() > 2 {
                 debug!("The --log-level option was incorrectly used more than twice. Ignoring third and further use.")
             }


### PR DESCRIPTION
This PR resolves issue #215.

We turn off all `matrix_sdk::http_client` logging unless the `RUST_LOG` environment variable has been set, or the `--debug` flag has been set, or the `--log-level` has been explicitly set.

We can re-enable `matrix_sdk` logging by either explicitly setting the `RUST_LOG` environment variable, or explicitly setting the `--log-level` flag. E.g.,

```bash
$ matrix-commander-rs --tail 1
```

will not log any trace messages from `matrix_sdk::http_client`. We can override this setting by running:
```bash
$ RUST_LOG='matrix_sdk=info' matrix-commander-rs --tail 1
```
or
```bash
$ matrix-commander-rs --log-level info --tail 1
```

**NOTE:** Cargo updated the version number in Cargo.lock