### PR TITLE
fix: fall back to matrix-commander-rs when device name is not provided

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2649,7 +2649,9 @@ fn get_device(ap: &mut Args) {
         }
         let trimmed_input = input.trim();
         if trimmed_input.is_empty() {
-            error!("Error: Empty device name is not allowed!");
+            let bin_name = get_bin_name().to_string();
+            ap.device = Some(bin_name.clone()); // Default to matrix-commander-rs
+            debug!("device is {bin_name}");
         } else {
             ap.device = Some(trimmed_input.to_string());
             debug!("device is {trimmed_input}");


### PR DESCRIPTION
During onboarding, matrix-commander-rs asks for a device name. Previously, the process would not continue unless the user provided one.

This change makes it default to matrix-commander-rs when the user does not provide a device name.

Closes #223