### PR TITLE
feat: Add redaction support in `--tail` (#228).

### DIFF
--- a/src/listen.rs
+++ b/src/listen.rs
@@ -59,7 +59,7 @@ use matrix_sdk::{
                 },
             },
             AnyMessageLikeEvent, AnyTimelineEvent, MessageLikeEvent, OriginalSyncMessageLikeEvent,
-            SyncMessageLikeEvent,
+            RedactedMessageLikeEvent, SyncMessageLikeEvent,
         },
         OwnedRoomId, OwnedUserId, RoomId, UInt,
     },
@@ -778,9 +778,9 @@ pub(crate) async fn listen_tail(
                     match anymessagelikeevent {
                         AnyMessageLikeEvent::RoomMessage(messagelikeevent) => {
                             debug!("value: {:?}", messagelikeevent);
+                            let room_id = OwnedRoomId::from(messagelikeevent.room_id());
                             match messagelikeevent {
                                 MessageLikeEvent::Original(originalmessagelikeevent) => {
-                                    let room_id = originalmessagelikeevent.room_id.clone();
                                     let originalsyncmessagelikeevent =
                                         OriginalSyncMessageLikeEvent::from(
                                             originalmessagelikeevent,
@@ -791,9 +791,18 @@ pub(crate) async fn listen_tail(
                                         &ctx,
                                     );
                                 }
-                                _ => {
-                                    warn!("RoomMessage type is not handled. Not implemented yet.");
-                                    err_count += 1;
+                                MessageLikeEvent::Redacted(redactedmessagelikeevent) => {
+                                    let RedactedMessageLikeEvent {
+                                        event_id, sender, ..
+                                    } = redactedmessagelikeevent;
+                                    if whoami != sender || listen_self {
+                                        println!(
+                                            "Redacted message: room {:?}, sender {:?}, event id {:?}, ",
+                                            room_id, sender, event_id
+                                        );
+                                    } else {
+                                        debug!("Skipping message from itself because --listen-self is not set.");
+                                    }
                                 }
                             }
                         }
@@ -802,37 +811,43 @@ pub(crate) async fn listen_tail(
                                 "Event of type RoomEncrypted received: {:?}",
                                 messagelikeevent
                             );
-                            // messagelikeevent is something like
-                            // RoomEncrypted: Original(OriginalMessageLikeEvent { content: RoomEncryptedEventContent { scheme: MegolmV1AesSha2(MegolmV1AesSha2Content { ciphertext: "xxx", sender_key: "yyy", device_id: "DDD", session_id: "sss" }), relates_to: Some(_Custom) }, event_id: "$eee", sender: "@sss:some.homeserver.org", origin_server_ts: MilliSecondsSinceUnixEpoch(123), room_id: "!roomid:some.homeserver.org",
-                            //      unsigned: MessageLikeUnsigned { age: Some(123), transaction_id: None, relations: None } })
-                            // Cannot be decrypted with jroom.decrypt_event(&anytimelineevent.event).await?;
-                            // because decrypt_event() only decrypts events from sync() and not from messages()
-
-                            match messagelikeevent {
-                                MessageLikeEvent::Original(originalmessagelikeevent) => {
-                                    debug!(
-                                    "New message: {:?} from sender {:?}, room {:?}, event_id {:?}",
-                                    originalmessagelikeevent.content,
-                                    originalmessagelikeevent.sender,
-                                    originalmessagelikeevent.room_id,
-                                    originalmessagelikeevent.event_id,
-                                );
-                                    if whoami != originalmessagelikeevent.sender || listen_self {
+                            if whoami != messagelikeevent.sender() || listen_self {
+                                // messagelikeevent is something like
+                                // RoomEncrypted: Original(OriginalMessageLikeEvent { content: RoomEncryptedEventContent { scheme: MegolmV1AesSha2(MegolmV1AesSha2Content { ciphertext: "xxx", sender_key: "yyy", device_id: "DDD", session_id: "sss" }), relates_to: Some(_Custom) }, event_id: "$eee", sender: "@sss:some.homeserver.org", origin_server_ts: MilliSecondsSinceUnixEpoch(123), room_id: "!roomid:some.homeserver.org",
+                                //      unsigned: MessageLikeUnsigned { age: Some(123), transaction_id: None, relations: None } })
+                                // Cannot be decrypted with jroom.decrypt_event(&anytimelineevent.event).await?;
+                                // because decrypt_event() only decrypts events from sync() and not from messages()
+                                match messagelikeevent {
+                                    MessageLikeEvent::Original(originalmessagelikeevent) => {
+                                        debug!(
+                                            "New message: {:?} from sender {:?}, room {:?}, event_id {:?}",
+                                            originalmessagelikeevent.content,
+                                            originalmessagelikeevent.sender,
+                                            originalmessagelikeevent.room_id,
+                                            originalmessagelikeevent.event_id,
+                                        );
                                         // The compiler knows that it is RoomMessageEventContent, because it comes from room::messages()
                                         // print_type_of(&originalmessagelikeevent.content); // ruma_common::events::room::message::RoomEncryptedEventContent
                                         println!(
                                             "Message: type Encrypted: body {:?}, room {:?}, sender {:?}, event_id {:?}, message could not be decrypted",
                                             originalmessagelikeevent.content, originalmessagelikeevent.room_id, originalmessagelikeevent.sender, originalmessagelikeevent.event_id,
                                         );
-                                        // has originalmessagelikeevent.content.relates_to.unwrap()
-                                    } else {
-                                        debug!("Skipping message from itself because --listen-self is not set.");
+                                    }
+                                    MessageLikeEvent::Redacted(redactedmessagelikeevent) => {
+                                        let RedactedMessageLikeEvent {
+                                            event_id,
+                                            sender,
+                                            room_id,
+                                            ..
+                                        } = redactedmessagelikeevent;
+                                        println!(
+                                            "Redacted message: room {:?}, sender {:?}, event id {:?}, ",
+                                            room_id, sender, event_id
+                                        );
                                     }
                                 }
-                                _ => {
-                                    warn!("RoomMessage type is not handled. Not implemented yet.");
-                                    err_count += 1;
-                                }
+                            } else {
+                                debug!("Skipping message from itself because --listen-self is not set.");
                             }
                         }
                         AnyMessageLikeEvent::RoomRedaction(messagelikeevent) => {

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -30,7 +30,7 @@ use matrix_sdk::{
     event_handler::Ctx,
     // SessionMeta,
     room::MessagesOptions,
-    // room,
+    // room
     room::Room,
     // ruma::
     ruma::{
@@ -53,7 +53,8 @@ use matrix_sdk::{
                     VideoMessageEventContent,
                 },
                 redaction::{
-                    OriginalSyncRoomRedactionEvent, RedactedSyncRoomRedactionEvent,
+                    OriginalRoomRedactionEvent, OriginalSyncRoomRedactionEvent,
+                    RedactedRoomRedactionEvent, RedactedSyncRoomRedactionEvent, RoomRedactionEvent,
                     SyncRoomRedactionEvent,
                 },
             },
@@ -67,6 +68,45 @@ use matrix_sdk::{
 
 /// Declare the items used from main.rs
 use crate::{Error, Output};
+
+/// Utility function to handle RoomRedactionEvent events.
+fn handle_roomredactionevent(ev: &RoomRedactionEvent, context: &Ctx<EvHandlerContext>) {
+    // This function is only called by `listen_tail` which doesn't support
+    // the `--output json` flag.
+    if context.whoami == ev.sender() && !context.listen_self {
+        debug!("Skipping redaction event from myself because --listen-self is not set.");
+        return;
+    }
+    match ev {
+        RoomRedactionEvent::Redacted(redactedmessageevent) => {
+            let RedactedRoomRedactionEvent {
+                content,
+                event_id,
+                sender,
+                room_id,
+                ..
+            } = redactedmessageevent;
+            println!(
+                "RoomRedaction: content: {:?}, room {:?}, sender {:?}, event id {:?}, ",
+                content, room_id, sender, event_id
+            );
+        }
+        RoomRedactionEvent::Original(redactedmessageevent) => {
+            let OriginalRoomRedactionEvent {
+                content,
+                redacts,
+                event_id,
+                sender,
+                room_id,
+                ..
+            } = redactedmessageevent;
+            println!(
+                "RoomRedaction: content: {:?}, redacts {:?}, room {:?}, sender {:?}, event id {:?}, ",
+                content, redacts, room_id, sender, event_id
+            );
+        }
+    }
+}
 
 /// Lower-level utility function to handle originalsyncmessagelikeevent
 fn handle_originalsyncmessagelikeevent(
@@ -796,8 +836,7 @@ pub(crate) async fn listen_tail(
                             }
                         }
                         AnyMessageLikeEvent::RoomRedaction(messagelikeevent) => {
-                            warn!("Event of type RoomRedaction received. Not implemented yet. value: {:?}", messagelikeevent);
-                            err_count += 1;
+                            handle_roomredactionevent(&messagelikeevent, &ctx);
                         }
                         // and many more
                         _ => {


### PR DESCRIPTION
This patch adds support for redaction events when calling matrix-commander with the `--tail` flag.

Example output from this patch: 
[matrix-commander-rs.log](https://github.com/user-attachments/files/30328685/matrix-commander-rs.log)

Closes #228 
